### PR TITLE
Input Icon Button Aria label fix

### DIFF
--- a/src/components/formFields/Input/Input.svelte
+++ b/src/components/formFields/Input/Input.svelte
@@ -268,7 +268,7 @@
     </label>
     {#if icon}
       {#if iconClick}
-        <button class="icon icon-cursor" on:click>
+        <button class="icon icon-cursor" aria-label={icon} on:click>
           <Icon iconName={icon} />
         </button>
       {:else}


### PR DESCRIPTION
In GitLab by @ismaelpamplona on Jan 18, 2023, 13:46

STORYBOOK ALERT
button -  Critical Element does not have inner text that is visible to screen readers -Serious aria-label attribute does not exist or is empty